### PR TITLE
[Feat/#23] : 요일별/시간대별 방문 통계 조회 API 구현

### DIFF
--- a/server/src/main/java/coumo/server/converter/StatisticsConverter.java
+++ b/server/src/main/java/coumo/server/converter/StatisticsConverter.java
@@ -2,15 +2,15 @@ package coumo.server.converter;
 
 import coumo.server.domain.Customer;
 import coumo.server.domain.mapping.CustomerStore;
-import coumo.server.web.dto.CustomerDTO;
+import coumo.server.web.dto.CustomerResponseDTO;
 
 import java.time.LocalDateTime;
 
 public class StatisticsConverter {
-    public static CustomerDTO toDTO(Customer customer, CustomerStore customerStore) {
+    public static CustomerResponseDTO toDTO(Customer customer, CustomerStore customerStore) {
         String ageGroup = calcAgeGroup(customer.getBirthday());
 
-        return CustomerDTO.builder()
+        return CustomerResponseDTO.builder()
                 .id(customer.getId())
                 .name(customer.getName())
                 .gender(customer.getGender())

--- a/server/src/main/java/coumo/server/repository/CustomerStoreRepository.java
+++ b/server/src/main/java/coumo/server/repository/CustomerStoreRepository.java
@@ -1,11 +1,19 @@
 package coumo.server.repository;
 
 import coumo.server.domain.Customer;
+import coumo.server.domain.Store;
 import coumo.server.domain.mapping.CustomerStore;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CustomerStoreRepository  extends JpaRepository<CustomerStore, Long> {
-    CustomerStore findByCustomerIdAndStoreId(Long id, Long storeId);
+    List<CustomerStore> findAllByCustomerIdAndStoreId(Long customerId, Long storeId);
+
+    @Query("SELECT COUNT(DISTINCT cs.id) FROM CustomerStore cs WHERE cs.store = :store AND HOUR(cs.updatedAt) = :hour AND DATE(cs.updatedAt) = :date")
+    int countByStoreAndHourAndDate(@Param("store") Store store, @Param("hour") int hour, @Param("date") LocalDate date);
+
 }

--- a/server/src/main/java/coumo/server/repository/StatisticsRepository.java
+++ b/server/src/main/java/coumo/server/repository/StatisticsRepository.java
@@ -19,4 +19,10 @@ public interface StatisticsRepository extends JpaRepository<Customer, Long> {
     @Query("SELECT cs.customer FROM CustomerStore cs WHERE cs.store.id = :storeId AND cs.stampTotal >= 10")
     List<Customer> getRegularCustomers(@Param("storeId") Long storeId);
 
+    @Query("SELECT DATE(cs.updatedAt) AS date, COUNT(DISTINCT cs.customer.id) " +
+            "FROM CustomerStore cs " +
+            "WHERE cs.store.id = :storeId AND DATE(cs.updatedAt) BETWEEN :startDate AND :endDate " +
+            "GROUP BY date")
+    List<Object[]> getWeekStatistics(Long storeId, LocalDate startDate, LocalDate endDate);
+
 }

--- a/server/src/main/java/coumo/server/repository/TimetableRepository.java
+++ b/server/src/main/java/coumo/server/repository/TimetableRepository.java
@@ -4,6 +4,10 @@ import coumo.server.domain.Store;
 import coumo.server.domain.Timetable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TimetableRepository extends JpaRepository<Timetable, Long> {
+    Optional<Timetable> findByStoreAndDay(Store store, String day);
+
     void deleteAllByStore(Store store);
 }

--- a/server/src/main/java/coumo/server/service/statistics/StatisticsService.java
+++ b/server/src/main/java/coumo/server/service/statistics/StatisticsService.java
@@ -2,16 +2,23 @@ package coumo.server.service.statistics;
 
 import coumo.server.converter.StatisticsConverter;
 import coumo.server.domain.Customer;
+import coumo.server.domain.Store;
+import coumo.server.domain.Timetable;
 import coumo.server.domain.mapping.CustomerStore;
 import coumo.server.repository.CustomerStoreRepository;
 import coumo.server.repository.StatisticsRepository;
-import coumo.server.web.dto.CustomerDTO;
+import coumo.server.repository.StoreRepository;
+import coumo.server.repository.TimetableRepository;
+import coumo.server.web.dto.CustomerResponseDTO;
+import coumo.server.web.dto.TimeResponseDTO;
+import coumo.server.web.dto.WeekResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.TextStyle;
 import java.util.*;
@@ -23,6 +30,8 @@ import java.util.stream.Collectors;
 public class StatisticsService {
     private final StatisticsRepository statisticsRepository;
     private final CustomerStoreRepository customerStoreRepository;
+    private final TimetableRepository timetableRepository;
+    private final StoreRepository storeRepository;
 
     /**
      * 전체 고객 데이터 확인
@@ -30,7 +39,7 @@ public class StatisticsService {
      */
     public Map<String, Object> getAllCustomers(Long storeId) {
         List<Customer> customers = statisticsRepository.getAllCustomers(storeId);
-        List<CustomerDTO> customerList = this.createCustomerDtoList(customers, storeId);
+        List<CustomerResponseDTO> customerList = this.createCustomerDtoList(customers, storeId);
 
         Map<String, Object> result = new HashMap<>();
         result.put("cnt", customers.size());
@@ -46,7 +55,7 @@ public class StatisticsService {
     public Map<String, Object> getNewCustomers(Long storeId) {
         LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
         List<Customer> newCustomers = statisticsRepository.getNewCustomers(storeId, oneMonthAgo);
-        List<CustomerDTO> newCustomerList = this.createCustomerDtoList(newCustomers, storeId);
+        List<CustomerResponseDTO> newCustomerList = this.createCustomerDtoList(newCustomers, storeId);
 
         Map<String, Object> result = new HashMap<>();
         result.put("cnt", newCustomers.size());
@@ -61,7 +70,7 @@ public class StatisticsService {
      */
     public Map<String, Object> getRegularCustomers(Long storeId) {
         List<Customer> regularCustomers = statisticsRepository.getRegularCustomers(storeId);
-        List<CustomerDTO> regularCustomerList = this.createCustomerDtoList(regularCustomers, storeId);
+        List<CustomerResponseDTO> regularCustomerList = this.createCustomerDtoList(regularCustomers, storeId);
 
         Map<String, Object> result = new HashMap<>();
         result.put("cnt", regularCustomers.size());
@@ -70,17 +79,87 @@ public class StatisticsService {
         return result;
     }
 
-    private List<CustomerDTO> createCustomerDtoList(List<Customer> customers, Long storeId) {
-        return customers.stream()
-                .map(customer -> {
-                    CustomerStore customerStore = customerStoreRepository.findByCustomerIdAndStoreId(customer.getId(), storeId);
-                    int totalStamp = (customerStore != null) ? customerStore.getStampTotal() : 0;
+    private List<CustomerResponseDTO> createCustomerDtoList(List<Customer> customers, Long storeId) {
+        List<CustomerResponseDTO> customerResponseDtoList = new ArrayList<>();
+        for (Customer customer : customers) {
+            List<CustomerStore> customerStores = customerStoreRepository.findAllByCustomerIdAndStoreId(customer.getId(), storeId);
+            for (CustomerStore customerStore : customerStores) {
+                int totalStamp = (customerStore != null) ? customerStore.getStampTotal() : 0;
 
-                    CustomerDTO customerDto = StatisticsConverter.toDTO(customer, customerStore);
-                    customerDto.setTotalStamp(totalStamp);
+                CustomerResponseDTO customerResponseDto = StatisticsConverter.toDTO(customer, customerStore);
+                customerResponseDto.setTotalStamp(totalStamp);
 
-                    return customerDto;
-                })
-                .collect(Collectors.toList());
+                customerResponseDtoList.add(customerResponseDto);
+            }
+        }
+        return customerResponseDtoList;
+    }
+
+
+    /**
+     * 요일 별 방문 통계 조회
+     * @param storeId 매장 ID
+     */
+    public List<WeekResponseDTO> getWeekStatistics(Long storeId) {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(6);
+
+        List<Object[]> results = statisticsRepository.getWeekStatistics(storeId, startDate, endDate);
+
+        Map<LocalDate, Long> resultByDate = results.stream()
+                .collect(Collectors.toMap(
+                        result -> {
+                            java.sql.Date sqlDate = (java.sql.Date) result[0];
+                            java.util.Date utilDate = new java.util.Date(sqlDate.getTime());
+                            return utilDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+                        },
+                        result -> (Long) result[1]
+                ));
+
+        List<WeekResponseDTO> weekStatistics = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = startDate.plusDays(i);
+            String day = date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.US).toUpperCase();
+            long totalCustomer = resultByDate.getOrDefault(date, 0L);
+
+            WeekResponseDTO weekResponseDto = new WeekResponseDTO(day, date, totalCustomer);
+            weekStatistics.add(weekResponseDto);
+        }
+
+        return weekStatistics;
+
+    }
+
+    /**
+     * 시간대 별 방문 통계 조회
+     * @param storeId 매장 ID
+     */
+    public List<TimeResponseDTO> getTimeStatistics(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new IllegalArgumentException("매장이 올바르지 않습니다."));
+
+        String day = LocalDate.now().getDayOfWeek().name();
+
+        Timetable timetable = timetableRepository.findByStoreAndDay(store, day)
+                .orElseThrow(() -> new IllegalArgumentException("시간 설정이 올바르지 않습니다."));
+
+        LocalTime currentTime = LocalTime.now();
+        LocalTime startTime = LocalTime.parse(timetable.getStartTime());
+        LocalTime endTime = LocalTime.parse(timetable.getEndTime());
+
+        List<TimeResponseDTO> result = new ArrayList<>();
+
+        for (int i = startTime.getHour(); i <= endTime.getHour(); i++) {
+            LocalTime time = LocalTime.of(i, 0);
+            if (time.isAfter(currentTime.minusHours(1))) {
+                result.add(new TimeResponseDTO(time, null));
+            } else {
+                int totalCustomer = customerStoreRepository.countByStoreAndHourAndDate(store, i, LocalDate.now());
+                result.add(new TimeResponseDTO(time, totalCustomer));
+            }
+        }
+
+
+        return result;
     }
 }

--- a/server/src/main/java/coumo/server/web/controller/StatisticsController.java
+++ b/server/src/main/java/coumo/server/web/controller/StatisticsController.java
@@ -29,4 +29,14 @@ public class StatisticsController {
     public ApiResponse<Map<String, Object>> getRegularCustomers(@PathVariable Long storeId) {
         return ApiResponse.onSuccess(statisticsService.getRegularCustomers(storeId));
     }
+
+    @GetMapping("/{storeId}/day")
+    public ApiResponse<?> getDayStatistics(@PathVariable Long storeId) {
+        return ApiResponse.onSuccess(statisticsService.getWeekStatistics(storeId));
+    }
+
+    @GetMapping("/{storeId}/time")
+    public ApiResponse<?> getTimeStatistics(@PathVariable Long storeId) {
+        return ApiResponse.onSuccess(statisticsService.getTimeStatistics(storeId));
+    }
 }

--- a/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Data
-public class CustomerDTO {
+public class CustomerResponseDTO {
     private Long id;
     private String name;
     private Gender gender;
@@ -18,7 +18,7 @@ public class CustomerDTO {
     private LocalDateTime updatedAt;
 
     @Builder
-    public CustomerDTO(Long id, String name, Gender gender, String birthday, String ageGroup, String phone, Integer totalStamp, LocalDateTime createdAt, LocalDateTime updatedAt){
+    public CustomerResponseDTO(Long id, String name, Gender gender, String birthday, String ageGroup, String phone, Integer totalStamp, LocalDateTime createdAt, LocalDateTime updatedAt){
         this.id=id;
         this.name=name;
         this.gender=gender;

--- a/server/src/main/java/coumo/server/web/dto/TimeResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/TimeResponseDTO.java
@@ -1,0 +1,19 @@
+package coumo.server.web.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalTime;
+
+@Data
+public class TimeResponseDTO {
+    private LocalTime startTime;
+    private Integer totalCustomer;
+
+    @Builder
+    public TimeResponseDTO(LocalTime startTime, Integer totalCustomer) {
+        this.startTime = startTime;
+        this.totalCustomer = totalCustomer;
+    }
+
+}

--- a/server/src/main/java/coumo/server/web/dto/WeekResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/WeekResponseDTO.java
@@ -1,0 +1,24 @@
+package coumo.server.web.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Data
+@Getter
+public class WeekResponseDTO {
+    private String day;
+    private LocalDate date;
+    private long totalCustomer;
+
+
+
+    @Builder
+    public WeekResponseDTO(String day, LocalDate date, long totalCustomer) {
+        this.day = day;
+        this.date = date;
+        this.totalCustomer = totalCustomer;
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 요일별 : 당일부터 일주일 이전까지에 해당하며, 해당 일주일 간 요일 별 방문자수를 구해주었습니다. 
- 시간대별 : 당일에 해당하며 startTime ~ endTime까지 실시간으로 totalCustomer를 셀 수 있도록 하였습니다. 현재 15:30일 경우, 14:00~15:00까지 방문자수까지만 반영하고, 이후 값들은 null처리 하였습니다. 

# ⚙️ ISSUE
- closed #23 


# 📷 Screenshot
- 요일별
![image](https://github.com/UMC-5th-Coumo/Coumo_Server/assets/96732525/2683610b-47c2-4e46-b03b-8a8d47ecda00)

- 시간대별
![image](https://github.com/UMC-5th-Coumo/Coumo_Server/assets/96732525/406dd2f2-ae6b-4687-baa6-e06df4bb092c)


# 💬 To Reviewers
부족한 부분이나 놓친 부분이 있다면 편하게 말씀해주세요!
