### PR TITLE
[Feat] 가게, 메뉴 조회 API 구현 - APP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Coumo_Server
+
+
+## 🌱 Server Member
+| <img src="https://avatars.githubusercontent.com/u/23547185?v=4" width=90px alt="버즈/강현우"/>  | <img src="https://avatars.githubusercontent.com/u/104756460?v=4" width=90px alt="통키/유수민"/>  | <img src="https://avatars.githubusercontent.com/u/150939763?v=4" width=90px alt="월리/정정교"/>  | <img src="https://avatars.githubusercontent.com/u/96732525?v=4" width=90px alt="샐리/조솔비"/>  |
+| :-----: | :-----: | :-----: | :-----: |
+| [버즈(강현우)](https://github.com/khwoowoo) | [통키(유수민)](https://github.com/proysm)  | [월리(정정교)](https://github.com/junggyo1020) | [샐리(조솔비)](https://github.com/chosolbee) |

--- a/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
+++ b/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
@@ -17,8 +17,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST,"COMMON400","데이터를 찾을 수 없습니다"),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _PAGE_OVER_RANGE(HttpStatus.BAD_REQUEST, "COMMON400", "페이징 범위를 넘었습니다. 페이징 0 부터 시작합니다."),
 
     STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","가게를 찾을 수 없습니다"),
+    STORE_IMAGE_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 매장 사진을 넣어주세요."),
+    STORE_MENU_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 메뉴는 입력해주세요."),
     STORE_MENU_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","menu json 형식이 잘 못 되었습니다"),
     STORE_MENU_COUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","메뉴 이미지 개수와 메뉴 json 개수가 다릅니다. 개수를 동일하게 설정해주세요"),
     STORE_POINT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","위도는 -90부터 90까지, 경도는 -180부터 180까지의 값을 가져야 합니다.");

--- a/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
+++ b/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
@@ -20,7 +20,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","가게를 찾을 수 없습니다"),
     STORE_MENU_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","menu json 형식이 잘 못 되었습니다"),
-    STORE_MENU_COUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","메뉴 이미지 개수와 메뉴 json 개수가 다릅니다. 개수를 동일하게 설정해주세요");
+    STORE_MENU_COUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","메뉴 이미지 개수와 메뉴 json 개수가 다릅니다. 개수를 동일하게 설정해주세요"),
+    STORE_POINT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","위도는 -90부터 90까지, 경도는 -180부터 180까지의 값을 가져야 합니다.");
 
 
 

--- a/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
+++ b/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
@@ -21,7 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     STORE_NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE,"STORE406","가게에 대한 자세한 정보가 없습니다. (사장님이 아직 쿠폰이나 가게 설정 부족)"),
-    STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","가게를 찾을 수 없습니다"),
+    STORE_CATEGORY_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","카테고리 입력이 잘 못 되었습니다"),
     STORE_IMAGE_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 매장 사진을 넣어주세요."),
     STORE_MENU_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 메뉴는 입력해주세요."),
     STORE_MENU_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","menu json 형식이 잘 못 되었습니다"),

--- a/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
+++ b/server/src/main/java/coumo/server/apiPayload/code/status/ErrorStatus.java
@@ -19,13 +19,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _PAGE_OVER_RANGE(HttpStatus.BAD_REQUEST, "COMMON400", "페이징 범위를 넘었습니다. 페이징 0 부터 시작합니다."),
 
+
+    STORE_NOT_ACCEPTABLE(HttpStatus.NOT_ACCEPTABLE,"STORE406","가게에 대한 자세한 정보가 없습니다. (사장님이 아직 쿠폰이나 가게 설정 부족)"),
     STORE_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","가게를 찾을 수 없습니다"),
     STORE_IMAGE_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 매장 사진을 넣어주세요."),
     STORE_MENU_NOT_EXIST(HttpStatus.BAD_REQUEST,"STORE400","최소 하나의 메뉴는 입력해주세요."),
     STORE_MENU_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","menu json 형식이 잘 못 되었습니다"),
     STORE_MENU_COUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","메뉴 이미지 개수와 메뉴 json 개수가 다릅니다. 개수를 동일하게 설정해주세요"),
     STORE_POINT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"STORE400","위도는 -90부터 90까지, 경도는 -180부터 180까지의 값을 가져야 합니다.");
-
 
 
     // 예시,,,

--- a/server/src/main/java/coumo/server/converter/StoreConverter.java
+++ b/server/src/main/java/coumo/server/converter/StoreConverter.java
@@ -4,6 +4,7 @@ import coumo.server.domain.Store;
 import coumo.server.web.dto.StoreResponseDTO;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,17 +44,17 @@ public class StoreConverter {
         return storeDetailDTO;
     }
 
-    public static List<StoreResponseDTO.FamousStoreDTO> toFamousStoreDTO(List<Store> stores){
-        if(stores.size() == 0) return null;
+    public static List<StoreResponseDTO.FamousStoreDTO> toFamousStoreDTO(List<StoreResponseDTO.StoreStampInfo> storeStampInfoList){
+        if(storeStampInfoList.isEmpty()) return Collections.emptyList();
 
         List<StoreResponseDTO.FamousStoreDTO> resultList = new ArrayList<>();
-
-        stores.stream()
+        storeStampInfoList.stream()
                 .map(item -> resultList.add(StoreResponseDTO.FamousStoreDTO.builder()
-                        .storeId(item.getId())
-                        .name(item.getName())
-                        .description(item.getStoreDescription())
-                        .storeImage(item.getStoreImageList().get(0).getStoreImage())
+                        .storeId(item.getStore().getId())
+                        .name(item.getStore().getName())
+                        .description(item.getStore().getStoreDescription())
+                        .location(item.getStore().getStoreLocation())
+                        .storeImage(item.getStore().getStoreImageList().get(0).getStoreImage())
                         .build()))
                 .collect(Collectors.toList());
 

--- a/server/src/main/java/coumo/server/converter/StoreConverter.java
+++ b/server/src/main/java/coumo/server/converter/StoreConverter.java
@@ -1,5 +1,6 @@
 package coumo.server.converter;
 
+import coumo.server.apiPayload.exception.handler.StoreHandler;
 import coumo.server.domain.Store;
 import coumo.server.web.dto.StoreResponseDTO;
 import org.springframework.data.domain.Page;
@@ -80,5 +81,37 @@ public class StoreConverter {
                 .collect(Collectors.toList());
 
         return resultList;
+    }
+
+    public static StoreResponseDTO.MoreDetailStoreDTO toMoreDetailStoreDTO(Store store, Long customerId){
+        StoreResponseDTO.MoreDetailStoreDTO result = StoreResponseDTO.MoreDetailStoreDTO.builder()
+                .name(store.getName())
+                .location(store.getStoreLocation())
+                .description(store.getStoreDescription())
+                .longitude(String.valueOf(store.getPoint().getX()))
+                .latitude(String.valueOf(store.getPoint().getY()))
+                .coupon(StoreResponseDTO.Coupon.builder()
+                        .title(store.getOwner().getOwnerCouponList().get(0).getStore_name())
+                        .cnt(store.getCustomerCouponLength(customerId))
+                        .color(store.getOwner().getOwnerCouponList().get(0).getColor())
+                        .build())
+                .images(new ArrayList<>())
+                .menus(new ArrayList<>())
+                .build();
+
+        store.getStoreImageList().stream()
+                .map(item->result.getImages().add(item.getStoreImage()))
+                .collect(Collectors.toList());
+
+        store.getMenuList().stream()
+                .map(item->result.getMenus().add(StoreResponseDTO.MenuInfo.builder()
+                                .name(item.getName())
+                                .description(item.getMenuDescription())
+                                .image(item.getMenuImage())
+                                .isNew(item.getIsNew())
+                        .build()))
+                .collect(Collectors.toList());
+
+        return result;
     }
 }

--- a/server/src/main/java/coumo/server/converter/StoreConverter.java
+++ b/server/src/main/java/coumo/server/converter/StoreConverter.java
@@ -4,6 +4,7 @@ import coumo.server.domain.Store;
 import coumo.server.web.dto.StoreResponseDTO;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class StoreConverter {
@@ -40,5 +41,22 @@ public class StoreConverter {
                         .add(new StoreResponseDTO.MenuInfo(item.getName(), item.getMenuImage(), item.getMenuDescription(), item.getIsNew())))
                 .collect(Collectors.toList());
         return storeDetailDTO;
+    }
+
+    public static List<StoreResponseDTO.FamousStoreDTO> toFamousStoreDTO(List<Store> stores){
+        if(stores.size() == 0) return null;
+
+        List<StoreResponseDTO.FamousStoreDTO> resultList = new ArrayList<>();
+
+        stores.stream()
+                .map(item -> resultList.add(StoreResponseDTO.FamousStoreDTO.builder()
+                        .storeId(item.getId())
+                        .name(item.getName())
+                        .description(item.getStoreDescription())
+                        .storeImage(item.getStoreImageList().get(0).getStoreImage())
+                        .build()))
+                .collect(Collectors.toList());
+
+        return resultList;
     }
 }

--- a/server/src/main/java/coumo/server/converter/StoreConverter.java
+++ b/server/src/main/java/coumo/server/converter/StoreConverter.java
@@ -2,6 +2,7 @@ package coumo.server.converter;
 
 import coumo.server.domain.Store;
 import coumo.server.web.dto.StoreResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -47,6 +48,7 @@ public class StoreConverter {
     public static List<StoreResponseDTO.FamousStoreDTO> toFamousStoreDTO(List<StoreResponseDTO.StoreStampInfo> storeStampInfoList){
         if(storeStampInfoList.isEmpty()) return Collections.emptyList();
 
+        //이미지 개수 예외처리 시급함
         List<StoreResponseDTO.FamousStoreDTO> resultList = new ArrayList<>();
         storeStampInfoList.stream()
                 .map(item -> resultList.add(StoreResponseDTO.FamousStoreDTO.builder()
@@ -55,6 +57,25 @@ public class StoreConverter {
                         .description(item.getStore().getStoreDescription())
                         .location(item.getStore().getStoreLocation())
                         .storeImage(item.getStore().getStoreImageList().get(0).getStoreImage())
+                        .build()))
+                .collect(Collectors.toList());
+
+        return resultList;
+    }
+
+    public static List<StoreResponseDTO.NearestStoreDTO> toNearestStoreDTO(Page<Store> storePage, Long customerId){
+        if(storePage.isEmpty()) return Collections.emptyList();
+
+        List<StoreResponseDTO.NearestStoreDTO> resultList = new ArrayList<>();
+        List<Store> storeList = storePage.getContent();
+        //이미지 개수 예외처리 시급함
+        storeList.stream()
+                .map(item -> resultList.add(StoreResponseDTO.NearestStoreDTO.builder()
+                                .storeId(item.getId())
+                                .storeImage(item.getStoreImageList().get(0).getStoreImage())
+                                .location(item.getStoreLocation())
+                                .couponCnt(item.getCustomerCouponLength(customerId))
+                                .name(item.getName())
                         .build()))
                 .collect(Collectors.toList());
 

--- a/server/src/main/java/coumo/server/domain/OwnerCoupon.java
+++ b/server/src/main/java/coumo/server/domain/OwnerCoupon.java
@@ -2,6 +2,7 @@ package coumo.server.domain;
 
 import coumo.server.domain.common.BaseEntity;
 import coumo.server.domain.enums.StampMax;
+import coumo.server.domain.mapping.CustomerStore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -35,4 +36,12 @@ public class OwnerCoupon extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(8)")
     private StampMax stampMax; //최대 스탬프 개수
+
+    //======== 비즈니스 로직 메서드 ========
+    public boolean isAvailable(){
+        if (color.isEmpty() || color.equals("") || store_name.isEmpty()
+                || store_name.equals("") || stampImage.isEmpty() || stampImage.equals(""))
+            return false;
+        return true;
+    }
 }

--- a/server/src/main/java/coumo/server/domain/Store.java
+++ b/server/src/main/java/coumo/server/domain/Store.java
@@ -116,7 +116,7 @@ public class Store extends BaseEntity {
     //======== 비즈니스 로직 메서드 ========
     public int getCustomerCouponLength(Long customerId){
         for (CustomerStore item : customerStoreList){
-            if(item.getStore().equals(this)){
+            if(item.getStore().equals(this) && item.getCustomer().getId().equals(customerId)){
                 return item.getStampCurrent();
             }
         }
@@ -125,7 +125,7 @@ public class Store extends BaseEntity {
 
     //======== 생성 메서드 ========
     public static Store createStore(Owner owner){
-        Point point = createPoint(0f, 0f);
+        Point point = createPoint(0.0, 0.0);
         Store store = Store.builder()
                         .name("")
                         .telephone("")

--- a/server/src/main/java/coumo/server/domain/Store.java
+++ b/server/src/main/java/coumo/server/domain/Store.java
@@ -112,6 +112,17 @@ public class Store extends BaseEntity {
         customerStore.setStore(this);
     }
 
+
+    //======== 비즈니스 로직 메서드 ========
+    public int getCustomerCouponLength(Long customerId){
+        for (CustomerStore item : customerStoreList){
+            if(item.getStore().equals(this)){
+                return item.getStampCurrent();
+            }
+        }
+        return -1;
+    }
+
     //======== 생성 메서드 ========
     public static Store createStore(Owner owner){
         Point point = createPoint(0f, 0f);

--- a/server/src/main/java/coumo/server/domain/Store.java
+++ b/server/src/main/java/coumo/server/domain/Store.java
@@ -107,6 +107,11 @@ public class Store extends BaseEntity {
         timetable.setStore(this);
     }
 
+    public void addCustomerStore(CustomerStore customerStore){
+        customerStoreList.add(customerStore);
+        customerStore.setStore(this);
+    }
+
     //======== 생성 메서드 ========
     public static Store createStore(Owner owner){
         Point point = createPoint(0f, 0f);

--- a/server/src/main/java/coumo/server/domain/enums/StoreType.java
+++ b/server/src/main/java/coumo/server/domain/enums/StoreType.java
@@ -1,5 +1,9 @@
 package coumo.server.domain.enums;
 
+import coumo.server.apiPayload.code.BaseErrorCode;
+import coumo.server.apiPayload.code.status.ErrorStatus;
+import coumo.server.apiPayload.exception.handler.StoreHandler;
+
 public enum StoreType {
     NONE("NONE"),
     ENTERTAINMENT("ENTERTAINMENT"),
@@ -18,10 +22,13 @@ public enum StoreType {
     public static StoreType fromString(String value) {
         for (StoreType type : StoreType.values()) {
             if (type.value.equalsIgnoreCase(value)) {
+                if (type.equals(StoreType.NONE)) throw new StoreHandler(ErrorStatus.STORE_CATEGORY_BAD_REQUEST);
                 return type;
             }
         }
-        return StoreType.NONE;
+
+        throw new StoreHandler(ErrorStatus.STORE_CATEGORY_BAD_REQUEST);
+        //return StoreType.NONE;
         //return null; // or throw IllegalArgumentException
     }
 }

--- a/server/src/main/java/coumo/server/domain/mapping/CustomerStore.java
+++ b/server/src/main/java/coumo/server/domain/mapping/CustomerStore.java
@@ -32,4 +32,8 @@ public class CustomerStore extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(8)")
     private StampMax stampMax; //최대 스탬프 개수
+
+    public void setStore(Store store) {
+        this.store = store;
+    }
 }

--- a/server/src/main/java/coumo/server/repository/StoreRepository.java
+++ b/server/src/main/java/coumo/server/repository/StoreRepository.java
@@ -11,16 +11,16 @@ import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
     @Query(value = "SELECT s.* FROM store AS s " +
-            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326))",
+            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type <> 'NONE'",
             countQuery = "SELECT count(*) FROM store AS s " +
-                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326))",
+                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type <> 'NONE'",
             nativeQuery = true)
     Page<Store> findNearByStores(Double x1, Double y1, Double x2, Double y2, Pageable pageable);
 
     @Query(value = "SELECT s.* FROM store AS s " +
-            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type = ?5",
+            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type <> 'NONE' AND s.store_type = ?5",
             countQuery = "SELECT count(*) FROM store AS s " +
-                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type = ?5",
+                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type <> 'NONE' AND s.store_type = ?5",
             nativeQuery = true)
     Page<Store> findNearByStores(Double x1, Double y1, Double x2, Double y2, String category, Pageable pageable);
 

--- a/server/src/main/java/coumo/server/repository/StoreRepository.java
+++ b/server/src/main/java/coumo/server/repository/StoreRepository.java
@@ -16,4 +16,12 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
                     "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326))",
             nativeQuery = true)
     Page<Store> findNearByStores(Double x1, Double y1, Double x2, Double y2, Pageable pageable);
+
+    @Query(value = "SELECT s.* FROM store AS s " +
+            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type = ?5",
+            countQuery = "SELECT count(*) FROM store AS s " +
+                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326)) AND s.store_type = ?5",
+            nativeQuery = true)
+    Page<Store> findNearByStores(Double x1, Double y1, Double x2, Double y2, String category, Pageable pageable);
+
 }

--- a/server/src/main/java/coumo/server/repository/StoreRepository.java
+++ b/server/src/main/java/coumo/server/repository/StoreRepository.java
@@ -1,7 +1,19 @@
 package coumo.server.repository;
 
 import coumo.server.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    @Query(value = "SELECT s.* FROM store AS s " +
+            "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326))",
+            countQuery = "SELECT count(*) FROM store AS s " +
+                    "WHERE MBRContains(ST_SRID(ST_LINESTRINGFROMTEXT(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')')), 4326), ST_SRID(s.point, 4326))",
+            nativeQuery = true)
+    Page<Store> findNearByStores(Double x1, Double y1, Double x2, Double y2, Pageable pageable);
 }

--- a/server/src/main/java/coumo/server/service/store/StoreQueryService.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryService.java
@@ -1,6 +1,7 @@
 package coumo.server.service.store;
 
 import coumo.server.domain.Store;
+import coumo.server.domain.enums.StoreType;
 import coumo.server.web.dto.StoreResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +12,7 @@ import java.util.Optional;
 public interface StoreQueryService {
     public Optional<Store> findStore(Long storeId);
     public List<StoreResponseDTO.StoreStampInfo> findFamousStore(double longitude, double latitude, double distance, Pageable pageable);
-    public Page<Store> findNearestStore(double longitude, double latitude, double distance, Pageable pageable);
-    public Optional<List<Store>> findNearestStore(double longitude, double latitude, String category, Long customerId);
+    public Page<Store> findNearestStore(double longitude, double latitude, double distance, Optional<String> category, Pageable pageable);
     public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId);
 
 }

--- a/server/src/main/java/coumo/server/service/store/StoreQueryService.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryService.java
@@ -13,6 +13,4 @@ public interface StoreQueryService {
     public Optional<Store> findStore(Long storeId);
     public List<StoreResponseDTO.StoreStampInfo> findFamousStore(double longitude, double latitude, double distance, Pageable pageable);
     public Page<Store> findNearestStore(double longitude, double latitude, double distance, Optional<String> category, Pageable pageable);
-    public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId);
-
 }

--- a/server/src/main/java/coumo/server/service/store/StoreQueryService.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryService.java
@@ -1,7 +1,6 @@
 package coumo.server.service.store;
 
 import coumo.server.domain.Store;
-import coumo.server.web.dto.StoreRequestDTO;
 import coumo.server.web.dto.StoreResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,7 +10,8 @@ import java.util.Optional;
 
 public interface StoreQueryService {
     public Optional<Store> findStore(Long storeId);
-    public Page<Store> findFamousStore(double longitude, double latitude, double distance, Pageable pageable);
+    public List<StoreResponseDTO.StoreStampInfo> findFamousStore(double longitude, double latitude, double distance, Pageable pageable);
+    public Page<Store> findNearestStore(double longitude, double latitude, double distance, Pageable pageable);
     public Optional<List<Store>> findNearestStore(double longitude, double latitude, String category, Long customerId);
     public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId);
 

--- a/server/src/main/java/coumo/server/service/store/StoreQueryService.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryService.java
@@ -4,14 +4,14 @@ import coumo.server.domain.Store;
 import coumo.server.web.dto.StoreRequestDTO;
 import coumo.server.web.dto.StoreResponseDTO;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface StoreQueryService {
     public Optional<Store> findStore(Long storeId);
-
-    public Page<Store> findFamousStore(double longitude, double latitude, double distance);
+    public Page<Store> findFamousStore(double longitude, double latitude, double distance, Pageable pageable);
     public Optional<List<Store>> findNearestStore(double longitude, double latitude, String category, Long customerId);
     public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId);
 

--- a/server/src/main/java/coumo/server/service/store/StoreQueryService.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryService.java
@@ -1,7 +1,9 @@
 package coumo.server.service.store;
 
 import coumo.server.domain.Store;
+import coumo.server.web.dto.StoreRequestDTO;
 import coumo.server.web.dto.StoreResponseDTO;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,8 +11,8 @@ import java.util.Optional;
 public interface StoreQueryService {
     public Optional<Store> findStore(Long storeId);
 
-    public Optional<List<Store>> findFamousStore(double x, double y);
-    public Optional<List<Store>> findNearestStore(double x, double y, String category, Long customerId);
+    public Page<Store> findFamousStore(double longitude, double latitude, double distance);
+    public Optional<List<Store>> findNearestStore(double longitude, double latitude, String category, Long customerId);
     public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId);
 
 }

--- a/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
@@ -1,26 +1,29 @@
 package coumo.server.service.store;
 
 import coumo.server.domain.Store;
+import coumo.server.domain.mapping.CustomerStore;
+import coumo.server.repository.CustomerStoreRepository;
 import coumo.server.repository.StoreRepository;
 import coumo.server.util.geometry.Direction;
 import coumo.server.util.geometry.GeometryUtil;
 import coumo.server.util.geometry.Location;
-import coumo.server.web.dto.StoreRequestDTO;
+import coumo.server.web.dto.StoreResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class StoreQueryServiceImpl implements StoreQueryService{
     private final StoreRepository storeRepository;
+    private final CustomerStoreRepository customerStoreRepository;
 
     @Override
     public Optional<Store> findStore(Long storeId) {
@@ -28,7 +31,31 @@ public class StoreQueryServiceImpl implements StoreQueryService{
     }
 
     @Override
-    public Page<Store> findFamousStore(double longitude, double latitude, double distance, Pageable pageable) {
+    public List<StoreResponseDTO.StoreStampInfo> findFamousStore(double longitude, double latitude, double distance, Pageable pageable) {
+        //근처 매장 찾기
+        Page<Store> pageStore = findNearestStore(longitude, latitude, distance, pageable);
+        if (pageStore.isEmpty()) return Collections.emptyList();
+
+        //쿠폰 도장이 기준
+        List<Store> stores = pageStore.getContent();
+        List<StoreResponseDTO.StoreStampInfo> storeStampInfos = new ArrayList<>();
+        for (Store store : stores) {
+            int total = 0;
+            for (CustomerStore item : store.getCustomerStoreList()) {
+                total += item.getStampTotal();
+            }
+            storeStampInfos.add(StoreResponseDTO.StoreStampInfo.builder()
+                                .store(store).stampTotal(total).build());
+        }
+
+        // StampTotal이 높은 순으로 정렬
+        storeStampInfos.sort((s1, s2) -> Integer.compare(s2.getStampTotal(), s1.getStampTotal()));
+
+        return storeStampInfos;
+    }
+
+    @Override
+    public Page<Store> findNearestStore(double longitude, double latitude, double distance, Pageable pageable) {
         Location northEast = GeometryUtil.calculate(latitude, longitude, distance, Direction.NORTHEAST.getBearing());
         Location southWest = GeometryUtil.calculate(latitude, longitude, distance, Direction.SOUTHWEST.getBearing());
 

--- a/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
@@ -28,7 +28,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
     }
 
     @Override
-    public Page<Store> findFamousStore(double longitude, double latitude, double distance) {
+    public Page<Store> findFamousStore(double longitude, double latitude, double distance, Pageable pageable) {
         Location northEast = GeometryUtil.calculate(latitude, longitude, distance, Direction.NORTHEAST.getBearing());
         Location southWest = GeometryUtil.calculate(latitude, longitude, distance, Direction.SOUTHWEST.getBearing());
 
@@ -37,8 +37,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         double x2 = southWest.getLatitude();
         double y2 = southWest.getLongitude();
 
-        Pageable pageable = PageRequest.of(0, 10);
-        return  storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
+        return storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
     }
 
     @Override

--- a/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
@@ -68,9 +68,4 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         if (category.isPresent()) return storeRepository.findNearByStores(x1, y1, x2, y2, category.get(), pageable);
         else return storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
     }
-
-    @Override
-    public Optional<Store> findStoreInfoMoreDetail(Long storeId, Long customerId) {
-        return Optional.empty();
-    }
 }

--- a/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class StoreQueryServiceImpl implements StoreQueryService{
     private final StoreRepository storeRepository;
-    private final CustomerStoreRepository customerStoreRepository;
 
     @Override
     public Optional<Store> findStore(Long storeId) {
@@ -66,11 +65,8 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         double x2 = southWest.getLatitude();
         double y2 = southWest.getLongitude();
 
-        if (category.isPresent()) {
-            return storeRepository.findNearByStores(x1, y1, x2, y2, category.get(), pageable);
-        } else {
-            return storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
-        }
+        if (category.isPresent()) return storeRepository.findNearByStores(x1, y1, x2, y2, category.get(), pageable);
+        else return storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
     }
 
     @Override

--- a/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/store/StoreQueryServiceImpl.java
@@ -2,7 +2,14 @@ package coumo.server.service.store;
 
 import coumo.server.domain.Store;
 import coumo.server.repository.StoreRepository;
+import coumo.server.util.geometry.Direction;
+import coumo.server.util.geometry.GeometryUtil;
+import coumo.server.util.geometry.Location;
+import coumo.server.web.dto.StoreRequestDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,12 +28,21 @@ public class StoreQueryServiceImpl implements StoreQueryService{
     }
 
     @Override
-    public Optional<List<Store>> findFamousStore(double x, double y) {
-        return Optional.empty();
+    public Page<Store> findFamousStore(double longitude, double latitude, double distance) {
+        Location northEast = GeometryUtil.calculate(latitude, longitude, distance, Direction.NORTHEAST.getBearing());
+        Location southWest = GeometryUtil.calculate(latitude, longitude, distance, Direction.SOUTHWEST.getBearing());
+
+        double x1 = northEast.getLatitude();
+        double y1 = northEast.getLongitude();
+        double x2 = southWest.getLatitude();
+        double y2 = southWest.getLongitude();
+
+        Pageable pageable = PageRequest.of(0, 10);
+        return  storeRepository.findNearByStores(x1, y1, x2, y2, pageable);
     }
 
     @Override
-    public Optional<List<Store>> findNearestStore(double x, double y, String category, Long customerId) {
+    public Optional<List<Store>> findNearestStore(double longitude, double latitude, String category, Long customerId) {
         return Optional.empty();
     }
 

--- a/server/src/main/java/coumo/server/util/geometry/Direction.java
+++ b/server/src/main/java/coumo/server/util/geometry/Direction.java
@@ -1,0 +1,21 @@
+package coumo.server.util.geometry;
+
+import lombok.Getter;
+
+@Getter
+public enum Direction {
+    NORTH(0.0),
+    WEST(270.0),
+    SOUTH(180.0),
+    EAST(90.0),
+    NORTHWEST(315.0),
+    SOUTHWEST(225.0),
+    SOUTHEAST(135.0),
+    NORTHEAST(45.0);
+
+    private final Double bearing;
+
+    Direction(Double bearing) {
+        this.bearing = bearing;
+    }
+}

--- a/server/src/main/java/coumo/server/util/geometry/GeometryUtil.java
+++ b/server/src/main/java/coumo/server/util/geometry/GeometryUtil.java
@@ -1,0 +1,44 @@
+package coumo.server.util.geometry;
+
+/**
+ * Haversine Formula
+ * φ2 = asin( sin φ1 ⋅ cos δ + cos φ1 ⋅ sin δ ⋅ cos θ )
+ * λ2 = λ1 + atan2( sin θ ⋅ sin δ ⋅ cos φ1, cos δ − sin φ1 ⋅ sin φ2 )
+ */
+public class GeometryUtil {
+    public static Location calculate(Double baseLatitude, Double baseLongitude, Double distance,
+                                     Double bearing) {
+        Double radianLatitude = toRadian(baseLatitude);
+        Double radianLongitude = toRadian(baseLongitude);
+        Double radianAngle = toRadian(bearing);
+        Double distanceRadius = distance / 6371.01;
+
+        Double latitude = Math.asin(sin(radianLatitude) * cos(distanceRadius) +
+                cos(radianLatitude) * sin(distanceRadius) * cos(radianAngle));
+        Double longitude = radianLongitude + Math.atan2(sin(radianAngle) * sin(distanceRadius) *
+                cos(radianLatitude), cos(distanceRadius) - sin(radianLatitude) * sin(latitude));
+
+        longitude = normalizeLongitude(longitude);
+        return new Location(toDegree(latitude), toDegree(longitude));
+    }
+
+    private static Double toRadian(Double coordinate) {
+        return coordinate * Math.PI / 180.0;
+    }
+
+    private static Double toDegree(Double coordinate) {
+        return coordinate * 180.0 / Math.PI;
+    }
+
+    private static Double sin(Double coordinate) {
+        return Math.sin(coordinate);
+    }
+
+    private static Double cos(Double coordinate) {
+        return Math.cos(coordinate);
+    }
+
+    private static Double normalizeLongitude(Double longitude) {
+        return (longitude + 540) % 360 - 180;
+    }
+}

--- a/server/src/main/java/coumo/server/util/geometry/Location.java
+++ b/server/src/main/java/coumo/server/util/geometry/Location.java
@@ -1,0 +1,15 @@
+package coumo.server.util.geometry;
+
+import lombok.Getter;
+
+@Getter
+public class Location {
+
+    private Double latitude;
+    private Double longitude;
+
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
@@ -1,6 +1,9 @@
 package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
+import coumo.server.apiPayload.code.status.ErrorStatus;
+import coumo.server.apiPayload.exception.handler.StoreHandler;
+import coumo.server.converter.StoreConverter;
 import coumo.server.domain.Store;
 import coumo.server.domain.enums.StoreType;
 import coumo.server.service.store.StoreCommandService;
@@ -8,6 +11,8 @@ import coumo.server.service.store.StoreQueryService;
 import coumo.server.web.dto.StoreResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -23,16 +28,21 @@ public class StoreAppRestController {
 
     @GetMapping("/store")
     public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getFamousStore(@RequestParam("longitude") Double longitude, @RequestParam("latitude") Double latitude) {
-        storeQueryService.findFamousStore(longitude, latitude, 0.5);
-        return ApiResponse.onSuccess(new ArrayList<>());
+        if (longitude < -180|| longitude > 180 || latitude > 90 || latitude < -90)  throw new StoreHandler(ErrorStatus.STORE_POINT_BAD_REQUEST);
+
+        Page<Store> famousStore = storeQueryService.findFamousStore(longitude, latitude, 0.5, PageRequest.of(0, 5));
+        log.info("Page<Store>={}", famousStore);
+        log.info("List<Store>={}", famousStore.getContent());
+        
+        return ApiResponse.onSuccess(StoreConverter.toFamousStoreDTO(famousStore.getContent()));
     }
 
 
     @GetMapping("/{customerId}/store/{storeId}")
     public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getNearestStore
-            (@RequestParam("category") StoreType category,
-             @PathVariable("customerId") Long customerId,
-             @PathVariable("storeId") Long storeId) {
+            (@RequestParam("longitude") Double longitude, @RequestParam("latitude") Double latitude,
+             @RequestParam("category") StoreType category,
+             @PathVariable("customerId") Long customerId, @PathVariable("storeId") Long storeId) {
         return ApiResponse.onSuccess(new ArrayList<>());
     }
 

--- a/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
@@ -11,7 +11,6 @@ import coumo.server.service.store.StoreQueryService;
 import coumo.server.web.dto.StoreResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,11 +29,9 @@ public class StoreAppRestController {
     public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getFamousStore(@RequestParam("longitude") Double longitude, @RequestParam("latitude") Double latitude) {
         if (longitude < -180|| longitude > 180 || latitude > 90 || latitude < -90)  throw new StoreHandler(ErrorStatus.STORE_POINT_BAD_REQUEST);
 
-        Page<Store> famousStore = storeQueryService.findFamousStore(longitude, latitude, 0.5, PageRequest.of(0, 5));
-        log.info("Page<Store>={}", famousStore);
-        log.info("List<Store>={}", famousStore.getContent());
-        
-        return ApiResponse.onSuccess(StoreConverter.toFamousStoreDTO(famousStore.getContent()));
+        List<StoreResponseDTO.StoreStampInfo> famousStore = storeQueryService.findFamousStore(longitude, latitude, 0.5, PageRequest.of(0, 5));
+
+        return ApiResponse.onSuccess(StoreConverter.toFamousStoreDTO(famousStore));
     }
 
 
@@ -43,6 +40,7 @@ public class StoreAppRestController {
             (@RequestParam("longitude") Double longitude, @RequestParam("latitude") Double latitude,
              @RequestParam("category") StoreType category,
              @PathVariable("customerId") Long customerId, @PathVariable("storeId") Long storeId) {
+
         return ApiResponse.onSuccess(new ArrayList<>());
     }
 

--- a/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
@@ -4,9 +4,10 @@ import coumo.server.apiPayload.ApiResponse;
 import coumo.server.domain.Store;
 import coumo.server.domain.enums.StoreType;
 import coumo.server.service.store.StoreCommandService;
-import coumo.server.web.dto.StoreRequestDTO;
+import coumo.server.service.store.StoreQueryService;
 import coumo.server.web.dto.StoreResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
@@ -15,13 +16,17 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/customer")
+@Slf4j
 public class StoreAppRestController {
     private final StoreCommandService storeCommandService;
+    private final StoreQueryService storeQueryService;
 
     @GetMapping("/store")
-    public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getFamousStore(@RequestBody StoreRequestDTO.PointDTO pointDTO) {
+    public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getFamousStore(@RequestParam("longitude") Double longitude, @RequestParam("latitude") Double latitude) {
+        storeQueryService.findFamousStore(longitude, latitude, 0.5);
         return ApiResponse.onSuccess(new ArrayList<>());
     }
+
 
     @GetMapping("/{customerId}/store/{storeId}")
     public ApiResponse<List<StoreResponseDTO.FamousStoreDTO>> getNearestStore

--- a/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/StoreAppRestController.java
@@ -6,7 +6,6 @@ import coumo.server.apiPayload.exception.handler.StoreHandler;
 import coumo.server.converter.StoreConverter;
 import coumo.server.domain.OwnerCoupon;
 import coumo.server.domain.Store;
-import coumo.server.domain.enums.StoreType;
 import coumo.server.service.store.StoreCommandService;
 import coumo.server.service.store.StoreQueryService;
 import coumo.server.web.dto.StoreResponseDTO;
@@ -16,7 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 

--- a/server/src/main/java/coumo/server/web/controller/StoreWebRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/StoreWebRestController.java
@@ -105,9 +105,9 @@ public class StoreWebRestController {
             @RequestPart("menuDetail") String menuDetailJson
             ){
 
-        //<수정 필요>
-        String[] storeImageUrl = {"", ""};
-        String[] menuImageUrl = {"", ""};
+        if (storeImages.length == 0) throw new StoreHandler(ErrorStatus.STORE_IMAGE_NOT_EXIST);
+        else if (menuImages.length == 0 || menuDetailJson.isEmpty()) throw new StoreHandler(ErrorStatus.STORE_MENU_NOT_EXIST);
+
         //[   {"name": "메뉴1", "description": "설명1"},   {"name": "메뉴2", "description": "설명2"} ]
         StoreRequestDTO.MenuDetail[] menuDetails;
         try{
@@ -115,6 +115,11 @@ public class StoreWebRestController {
         } catch (JsonProcessingException e){
             throw new StoreHandler(ErrorStatus.STORE_MENU_BAD_REQUEST);
         }
+
+        //<수정 필요> 이미지 없으면 빈 문자열 넣자
+        String[] storeImageUrl = {"", ""};
+        String[] menuImageUrl = {"", ""};
+
         storeCommandService.updateStore(storeId, description, storeImageUrl, menuImageUrl, menuDetails);
         return ApiResponse.onSuccess(storeId);
     }

--- a/server/src/main/java/coumo/server/web/dto/StoreRequestDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/StoreRequestDTO.java
@@ -46,7 +46,9 @@ public class StoreRequestDTO {
 
     @Getter
     public static class PointDTO{
-        public String longitude;
-        public String latitude;
+        @NotBlank
+        public Double longitude;
+        @NotBlank
+        public Double latitude;
     }
 }

--- a/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
@@ -1,5 +1,6 @@
 package coumo.server.web.dto;
 
+import coumo.server.domain.Store;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -86,6 +87,14 @@ public class StoreResponseDTO {
         Coupon coupon;
         List<String> images;
         List<MenuMoreDate> menus;
+    }
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class StoreStampInfo {
+        private Store store;
+        private int stampTotal;
     }
 
     @Builder

--- a/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
@@ -98,7 +98,7 @@ public class StoreResponseDTO {
         String latitude;
         Coupon coupon;
         List<String> images;
-        List<MenuMoreDate> menus;
+        List<MenuInfo> menus;
     }
     @Builder
     @Getter
@@ -118,17 +118,5 @@ public class StoreResponseDTO {
         Integer cnt;
         String stampType;
         String color;
-    }
-
-    @Builder
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class MenuMoreDate{
-        String name;
-        String description;
-        String image;
-        LocalDateTime createdAt;
-        LocalDateTime updatedAt;
     }
 }

--- a/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/StoreResponseDTO.java
@@ -78,6 +78,18 @@ public class StoreResponseDTO {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class NearestStoreDTO {
+        Long storeId;
+        String name;
+        String location;
+        Integer couponCnt;
+        String storeImage;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class MoreDetailStoreDTO{
         String name;
         String description;


### PR DESCRIPTION
# 📄 Work Description
- 반경 500m 안에 가게 찾아서 정보를 조회하는 API 입니다!

# ⚙️ ISSUE
- closed #18

# 📷 Screenshot
 - 스웨거
 - 가까운 매장 찾기 및 인기순으로 정렬
<img width="1062" alt="스크린샷 2024-02-01 오후 4 34 52" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/23547185/72e61f36-28b1-4c73-b565-a576b48e1c4c">

 - 카테고리로 가까운 매장 찾기
<img width="942" alt="스크린샷 2024-02-01 오후 4 35 46" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/23547185/b23a7770-96bf-495c-ac4c-61123ac61de3">

 - 가게 상세 정보 보기
<img width="943" alt="스크린샷 2024-02-01 오후 4 36 18" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/23547185/c3d02463-89ef-4aae-bec1-f7507f0c73dd">


# 💬 To Reviewers
구현은 다 했습니다.
마지막 가게 상세 정보 보기 같은 경우 쿠폰의 정보(색상, 이름 등)이 없으면 예외처리해서 보이지는 않지만 코드가 복잡하지는 않아서 잘 동작할 것 같습니다. 이건 나중에 어느정도 구현이 되었다면 다시 테스트하고 문제 있으면 새로 PR 올리겠습니다!

또한, 쿠폰이 1:N 관계라서 여러 개가 존재하는데, 데모데이까지는 쿠폰은 1개라고 알고있으며 어떤게 어떤 쿠폰인지 판단할 무언가가 아직 없어서 무조건 1번째 쿠폰에 대한 정보를 반환하게 했습니다!

```
StoreResponseDTO.MoreDetailStoreDTO result = StoreResponseDTO.MoreDetailStoreDTO.builder()
                .name(store.getName())
                .location(store.getStoreLocation())
                .description(store.getStoreDescription())
                .longitude(String.valueOf(store.getPoint().getX()))
                .latitude(String.valueOf(store.getPoint().getY()))
                .coupon(StoreResponseDTO.Coupon.builder()
                        .title(store.getOwner().getOwnerCouponList().get(0).getStore_name())
                        .cnt(store.getCustomerCouponLength(customerId))
                        .color(store.getOwner().getOwnerCouponList().get(0).getColor())
                        .build())
                .images(new ArrayList<>())
                .menus(new ArrayList<>())
                .build();
```
